### PR TITLE
Fixed extra `>` after question 12 select

### DIFF
--- a/thequiz.html
+++ b/thequiz.html
@@ -233,7 +233,7 @@
                 <option value=-8.766>Kinda disagree</option>
                 <option value=-17.533>Strongly disagree</option>
             
-            </select>>
+            </select>
         </div>    
         <div class="questions" id="que13">
             <p>The harder you work, the more you progress up the social ladder.</p>


### PR DESCRIPTION
Minor text fix. The extra `>` is showing through to the user.

![extra_alligator](https://user-images.githubusercontent.com/9843883/89446847-138c2400-d723-11ea-97ff-0433345f90b6.png)
